### PR TITLE
Fix issue with the second page of row stuff

### DIFF
--- a/themes/castanet/layouts/partials/row.html
+++ b/themes/castanet/layouts/partials/row.html
@@ -134,12 +134,6 @@
         {{- $.Scratch.Set "truncate" 600 -}}
       {{- end -}}
     {{- end -}}
-    {{- with .Params.youtube -}}
-      {{- $.Scratch.Set "youtube" "true" -}}
-    {{- end -}}
-    {{- with .Params.episode_banner -}}
-      {{- $.Scratch.Set "episode_banner" "true" -}}
-    {{- end -}}
       <div class = "row homepage_episode_row">
         <div class = "col-md-12">
           <a href="{{ .Permalink }}" class= "grid_episode_title"><h3 class= "grid_episode_title">{{ .Title }}</h3></a>


### PR DESCRIPTION
This is being fixed in the underlying theme, but until that fix is released, this should work as a patch.